### PR TITLE
Fixing Typos on the Index Page!

### DIFF
--- a/home.body.php
+++ b/home.body.php
@@ -38,7 +38,7 @@
                         <div class="section__text mdl-cell mdl-cell--10-col-desktop mdl-cell--6-col-tablet mdl-cell--3-col-phone">
                             <h4>Privacy</h4>
                             Parrot includes by default TOR, I2P, anonsurf, gpg, tccf, zulucrypt, veracrypt, truecrypt, luks
-                            and many other tecnologies designed to defend your privacy and your identity.<br><br>
+                            and many other technologies designed to defend your privacy and your identity.<br><br>
                         </div>
                         <div class="section__circle-container mdl-cell mdl-cell--2-col mdl-cell--1-col-phone">
                             <div class="section__circle-container__circle mdl-color--primary"><h2 align="center"><font color="#fff">{}</font></h2></div>

--- a/home.body.php
+++ b/home.body.php
@@ -72,7 +72,7 @@
                     <a href="https://dasaweb.net/cart.php?gid=18" target="_blank" style="color:#666">
                         <h4>Dasaweb and Parrot Cloud</h4>
                         Dasaweb a great european provider, now sells VPS with parrot cloud pre-installed.<br>
-                        The service is maintained in collaboration with the Parrot Core Team and the service seems to have an exponential polularity.
+                        The service is maintained in collaboration with the Parrot Core Team and the service seems to have an exponential popularity.
                     </a>
                 </div>
                 <div class="section__circle-container mdl-cell mdl-cell--2-col mdl-cell--1-col-phone">


### PR DESCRIPTION
Fixed a typo in the Dasaweb and Parrot Cloud section. (polularity -> popularity)

Also fixed a typo in the Details/Privacy feature box (tecnologies -> technologies) resolving #6 by @20yuroti
Note: in the commit message I used singular instead of plural. The change itself, however, retains the plurality of the word while correcting the spelling.